### PR TITLE
Add support for building service as Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM node:8-alpine
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 8080
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -3,3 +3,54 @@
 [![Build Status](https://travis-ci.org/jamiemjennings/crypto-rest-api.svg?branch=master)](https://travis-ci.org/jamiemjennings/crypto-rest-api)
 
 This project is a work-in-progress. The intention is to build a multi-tenanted REST API for encryption/decryption of data, while learning some new technologies.
+
+## To Run the Service Locally (outside Docker)
+```
+node index.js
+```
+or you can use [nodemon](https://nodemon.io/) to test the service during development.
+
+## To Build a Docker Image for the Service
+
+```
+docker build -t jamiemjennings/crypto-rest-api .
+```
+
+## To Run the Service in Docker
+
+First build the service image using the instructions above, then:
+
+```
+docker run -p 8888:8080 -d jamiemjennings/crypto-rest-api
+```
+Change `8888` to your preferred port on which to access the service on localhost.
+
+## Test Service API
+
+You may submit test requests to the API using `cURL` as follows:
+
+**Encrypt Endpoint**
+```
+✗ curl -X POST -H "content-type: application/json" -d '{}' -i localhost:8080/v1/encrypt
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+X-Response-Time: 3ms
+Content-Length: 55
+Date: Wed, 21 Feb 2018 02:32:22 GMT
+Connection: keep-alive
+
+{"keyName":"testKeyName","cipherText":"encrypted_data"}
+```
+
+**Decrypt endpoint**
+```
+✗ curl -X POST -H "content-type: application/json" -d '{}' -i localhost:8080/v1/decrypt
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+X-Response-Time: 2ms
+Content-Length: 54
+Date: Wed, 21 Feb 2018 02:42:34 GMT
+Connection: keep-alive
+
+{"keyName":"testKeyName","plaintext":"decrypted_data"}
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+      "dev": true,
       "requires": {
         "samsam": "1.3.0"
       }
@@ -475,7 +476,8 @@
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
-      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww=="
+      "integrity": "sha512-MKPHZDMB0o6yHyDryUOScqZibp914ksXwAMYMTHj6KO8UeKsRYNJD3oNCKjTqZon+V488P7N/HzXF8t7ZR95ww==",
+      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
@@ -985,7 +987,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "he": {
       "version": "1.1.1",
@@ -1244,7 +1247,8 @@
     "just-extend": {
       "version": "1.1.27",
       "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-1.1.27.tgz",
-      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g=="
+      "integrity": "sha512-mJVp13Ix6gFo3SBAy9U/kL+oeZqzlYYYLQBwXVBlVzIsZwBqGREnOro24oC/8s8aox+rJhtZ2DiQof++IrkA+g==",
+      "dev": true
     },
     "keygrip": {
       "version": "1.0.2",
@@ -1376,12 +1380,14 @@
     "lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
     },
     "lolex": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.3.2.tgz",
-      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng=="
+      "integrity": "sha512-A5pN2tkFj7H0dGIAM6MFvHKMJcPnjZsOMvR7ujCjfgW5TbV6H9vb1PgxLtHvjqNZTHsUolz+6/WEO0N1xNx2ng==",
+      "dev": true
     },
     "loose-envify": {
       "version": "1.3.1",
@@ -1516,6 +1522,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
       "integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
+      "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "just-extend": "1.1.27",
@@ -1974,7 +1981,8 @@
     "samsam": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
-      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg=="
+      "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
+      "dev": true
     },
     "semver": {
       "version": "5.5.0",
@@ -2018,6 +2026,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
       "integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
+      "dev": true,
       "requires": {
         "@sinonjs/formatio": "2.0.0",
         "diff": "3.3.1",
@@ -2032,6 +2041,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
           "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
+          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -2187,7 +2197,8 @@
     "text-encoding": {
       "version": "0.6.4",
       "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
-      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk="
+      "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+      "dev": true
     },
     "text-table": {
       "version": "0.2.0",
@@ -2222,7 +2233,8 @@
     "type-detect": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "dev": true
     },
     "type-is": {
       "version": "1.6.16",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node index.js",
     "test": "standard && mocha --recursive tests/"
   },
   "author": "Jamie Jennings <jamiemjennings@gmail.com> (https://github.com/jamiemjennings)",


### PR DESCRIPTION
This PR introduces the following changes:
- Add `npm start` script
- Add Dockerfile to allow building a Docker image of the sevice
- README updates with developer instructions
- New `.dockerignore` file and `package-lock.json` updates.