### PR TITLE
Add docker-compose support for running the service

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ First build the service image using the instructions above, then:
 ```
 docker run -p 8888:8080 -d jamiemjennings/crypto-rest-api
 ```
+or you may use [docker-compose](https://docs.docker.com/compose/):
+```
+docker-compose up -d
+```
+
 Change `8888` to your preferred port on which to access the service on localhost.
 
 ## Test Service API

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '3'
+services:
+  crypto-rest-api:
+    image: jamiemjennings/crypto-rest-api
+    ports:
+      - 8888:8080


### PR DESCRIPTION
Add support for running the service in a Docker container via `docker-compose`. 