### PR TITLE
Add health check endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,6 @@
 const Koa = require('koa')
 const app = new Koa()
 
-const EncryptRouter = require('./routes/encrypt')
-const encryptRouter = new EncryptRouter()
-const DecryptRouter = require('./routes/decrypt')
-const decryptRouter = new DecryptRouter()
-
 const HTTP_PORT = process.env.HTTP_PORT || 8080
 
 app.on('error', (err, ctx) => {
@@ -38,8 +33,8 @@ app.use(async (ctx, next) => {
   next()
 })
 
-encryptRouter.getRoutes().forEach((route) => { app.use(route) })
-decryptRouter.getRoutes().forEach((route) => { app.use(route) })
+const routes = require('./routes')
+routes.getRoutes().forEach((route) => { app.use(route) })
 
 app.listen(HTTP_PORT)
 console.log(`Service running on port ${HTTP_PORT}`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1368,8 +1368,7 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.cond": {
       "version": "4.5.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   "license": "ISC",
   "dependencies": {
     "koa": "^2.5.0",
-    "koa-route": "^3.2.0"
+    "koa-route": "^3.2.0",
+    "lodash": "^4.17.5"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/routes/health.js
+++ b/routes/health.js
@@ -1,0 +1,22 @@
+const koaRoute = require('koa-route')
+
+class HealthRouter {
+  constructor (options = {}) {
+    this.healthPath = options.healthPath || '/_health'
+    this.logger = options.logger || require('../util/defaultLogger')
+  }
+
+  getHealth (ctx, next) {
+    ctx.body = { status: 'OK' }
+    ctx.status = 200
+    next()
+  }
+
+  getRoutes () {
+    return [
+      koaRoute.get(this.healthPath, this.getHealth.bind(this))
+    ]
+  }
+}
+
+module.exports = HealthRouter

--- a/routes/health.js
+++ b/routes/health.js
@@ -1,8 +1,11 @@
 const koaRoute = require('koa-route')
+const _ = require('lodash')
+
+const DEFAULT_HEALTH_ROUTE = '/_health'
 
 class HealthRouter {
   constructor (options = {}) {
-    this.healthPath = options.healthPath || '/_health'
+    this.healthPath = HealthRouter._normalizeHealthPath(options.healthPath)
     this.logger = options.logger || require('../util/defaultLogger')
   }
 
@@ -16,6 +19,16 @@ class HealthRouter {
     return [
       koaRoute.get(this.healthPath, this.getHealth.bind(this))
     ]
+  }
+
+  static _normalizeHealthPath (val) {
+    if (!val) {
+      return DEFAULT_HEALTH_ROUTE
+    }
+    if (!_.isString(val) || val.trim().length < 2 || val.lastIndexOf('/') > 0) {
+      throw new Error(`Invalid health path value: ${val}`)
+    }
+    return val.startsWith('/') ? val.trim() : `/${val.trim()}`
   }
 }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,0 +1,15 @@
+const _ = require('lodash')
+
+const DecryptRouter = require('./decrypt')
+const EncryptRouter = require('./encrypt')
+const HealthRouter = require('./health')
+
+module.exports = {
+  getRoutes () {
+    let toReturn = []
+    toReturn = _.concat(toReturn, new DecryptRouter().getRoutes())
+    toReturn = _.concat(toReturn, new EncryptRouter().getRoutes())
+    toReturn = _.concat(toReturn, new HealthRouter({healthPath: '/_health'}).getRoutes())
+    return toReturn
+  }
+}

--- a/tests/routes/health.test.js
+++ b/tests/routes/health.test.js
@@ -1,0 +1,45 @@
+const assert = require('chai').assert
+const HealthRouter = require('../../routes/health')
+const blankLogger = require('../blankLogger')
+
+describe('HealthRouter', function () {
+  var router
+  beforeEach(() => {
+    router = new HealthRouter({logger: blankLogger})
+  })
+  describe('constructor', function () {
+    it('accepts a no-arg constructor', () => {
+      let instance = new HealthRouter()
+      assert.isNotNull(instance)
+    })
+    it('accepts a custom logger', () => {
+      let myLogger = { a: '123' }
+      let instance = new HealthRouter({logger: myLogger})
+      assert.isNotNull(instance)
+      assert.deepEqual(instance.logger, myLogger)
+    })
+    it('accepts a custom route path on healthPath property', () => {
+      let instance = new HealthRouter({healthPath: '/testHealthPath123'})
+      assert.isNotNull(instance)
+      assert.isNotNull(instance.logger)
+      assert.equal(instance.healthPath, '/testHealthPath123')
+    })
+  })
+  describe('getHealth()', () => {
+    it('sets 200 status, returns status OK body and calls next()', (done) => {
+      let ctx = {}
+      router.getHealth(ctx, () => {
+        assert.deepEqual(ctx.body, { status: 'OK' })
+        assert.equal(ctx.status, 200)
+        done()
+      })
+    })
+  })
+  describe('getRoutes()', function () {
+    it('returns an array of routes', () => {
+      let routes = router.getRoutes()
+      assert.isArray(routes)
+      assert.isNotEmpty(routes)
+    })
+  })
+})

--- a/tests/routes/health.test.js
+++ b/tests/routes/health.test.js
@@ -42,4 +42,47 @@ describe('HealthRouter', function () {
       assert.isNotEmpty(routes)
     })
   })
+  describe('_normalizeHealthPath()', function () {
+    let emptyTests = [
+      { val: null, desc: 'Returns default for null' },
+      { val: undefined, desc: 'Returns default for null' },
+      { val: '', desc: 'Returns default for empty string' }
+    ]
+    emptyTests.forEach((testData) => {
+      it(testData.desc, () => {
+        let val = HealthRouter._normalizeHealthPath(testData.val)
+        assert.equal(val, '/_health')
+      })
+    })
+    let invalidValTests = [
+      { val: '   ', desc: 'Throws error for whitespace' },
+      { val: '  \t', desc: 'Throws error for whitespace with tab' },
+      { val: 123, desc: 'Throws error for integer' },
+      { val: {}, desc: 'Throws error for Object' },
+      { val: [], desc: 'Throws error for array' },
+      { val: '/util/healthcheck', desc: 'Throws error for nested path' },
+      { val: '/healthcheck/', desc: 'Throws error for trailing slash' }
+    ]
+    invalidValTests.forEach((testData) => {
+      it(testData.desc, (done) => {
+        try {
+          HealthRouter._normalizeHealthPath(testData.val)
+        } catch (err) {
+          assert.isNotNull(err)
+          assert.equal(err, `Error: Invalid health path value: ${testData.val}`)
+          done()
+        }
+      })
+    })
+    let validTests = [
+      { input: '/foobar', expected: '/foobar', desc: 'Returns valid path' },
+      { input: 'foobar', expected: '/foobar', desc: 'Prepends / if not exists' }
+    ]
+    validTests.forEach((testData) => {
+      it(testData.desc, () => {
+        let val = HealthRouter._normalizeHealthPath(testData.input)
+        assert.equal(val, testData.expected)
+      })
+    })
+  })
 })

--- a/tests/routes/index.test.js
+++ b/tests/routes/index.test.js
@@ -1,0 +1,12 @@
+const assert = require('chai').assert
+const routesIndex = require('../../routes')
+
+describe('routes/index', function () {
+  describe('getRoutes()', function () {
+    it('returns an array of routes', () => {
+      let routes = routesIndex.getRoutes()
+      assert.isArray(routes)
+      assert.isNotEmpty(routes)
+    })
+  })
+})


### PR DESCRIPTION
Adds a health check endpoint on `/_health`. Health check will return JSON response:
```
{ status: "OK" }
```
with HTTP status 200 if the service is up.

This PR also moves assembly of router paths to `routes/index.js` from the main `/index.js` file.

Fixes https://github.com/jamiemjennings/crypto-rest-api/issues/6